### PR TITLE
Added Support to Deploy Linux VM based on Image with 2 disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ module "example-server-linuxvm-withdatadisk" {
   ds                 = "Data Store name"
 }
 
+module "example-server-linuxvm-with-2-image-disk" {
+  source             = "Terraform-VMWare-Modules/vm3nic/vsphere"
+  version            = "0.2.0"
+  vmtemp             = "TemplateName"
+  instances          = 1
+  vmname             = "example-server-windows"
+  vmrp               = "esxi/Resources"  
+  net01              = "Name of the VLAN in vSphere for the first NIC"
+  net02              = "Name of the VLAN in vSphere for the Second NIC"
+  net03              = "Name of the VLAN in vSphere for the Third NIC"
+  data_disk          = "true"
+  data_disk_size_gb  = 20
+  dc                 = "Datacenter"
+  ds                 = "Data Store name"
+  template_with_dual_disk= "true"
+}
+
+
+
 module "example-server-windowsvm-withdatadisk" {
   source            = "Terraform-VMWare-Modules/vm3nic/vsphere"
   version           = "0.1.0"
@@ -70,6 +89,7 @@ There are number of switches defined in the module, where you can use to enable 
 * You can use `is_windows_image = "true"` to set the customization type to Windows (By default it is set to Linux customization)
 * You can use `data_disk = "true"` to add one additional disk (Supported in both Linux and Windows deployment)
   * By default it is set to 20GB. You can modify it by using `data_disk_size_gb` variable.
+* You can use 'template_with_dual_disk = "true"' to set terraform for deploy a linux image with already 2 disks.
 
 Below is an example of windows deployment with all available feature sets.
 

--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -48,6 +48,28 @@ module "example-server-linuxvm-withdatadisk" {
 }
 ```
 
+
+### Example of Linux VM with image created with 2 disks.
+
+```hcl
+module "example-server-linuxvm-image-2-disks" {
+  source            = "Terraform-VMWare-Modules/vm3nic/vsphere"
+  version           = "0.1.0"
+  vmtemp            = "TemplateName"
+  instances         = 1
+  vmname            = "example-server-windows"
+  vmrp              = "esxi/Resources"  
+  net01              = "Name of the VLAN in vSphere for the first NIC"
+  net02              = "Name of the VLAN in vSphere for the Second NIC"
+  net03              = "Name of the VLAN in vSphere for the Third NIC"
+  data_disk         = "true"
+  data_disk_size_gb = 20
+  dc                = "Datacenter"
+  ds_cluster        = "Data Store Cluster name"
+  template_with_dual_disk = "true"
+}
+```
+
 ## Authors
 
 Originally created by [Arman Keyoumarsi](https://github.com/Arman-Keyoumarsi)

--- a/examples/linux/main.tf
+++ b/examples/linux/main.tf
@@ -31,3 +31,23 @@ module "example-server-linuxvm-withdatadisk" {
   dc                = "Datacenter"
   ds                = "Data Store Cluster name"
 }
+
+
+// Example of Linux VM based on Image with 2 disks.
+module "example-server-linuxvm-image-with2-disks" {
+  source            = "Terraform-VMWare-Modules/vm3nic/vsphere"
+  version           = "0.2.0"
+  vmtemp            = "TemplateName"
+  instances         = 1
+  vmname            = "example-server-windows"
+  vmrp              = "esxi/Resources"
+  net01             = "Name of the VLAN in vSphere for the first NIC"
+  net02             = "Name of the VLAN in vSphere for the Second NIC"
+  net03             = "Name of the VLAN in vSphere for the Third NIC"
+  data_disk         = "true"
+  data_disk_size_gb = 20
+  dc                = "Datacenter"
+  ds                = "Data Store Cluster name"
+  template_with_dual_disk = "true"
+}
+

--- a/main.tf
+++ b/main.tf
@@ -146,6 +146,70 @@ resource "vsphere_virtual_machine" "LinuxVM-withDataDisk" {
     }
   }
 }
+
+// Creating Linux VM based on Image with 2 Disks.
+resource "vsphere_virtual_machine" "LinuxVM-DualDisk" {
+  count            = "${ var.is_windows_image != "true" && var.template_with_dual_disk == "true" ? var.instances : 0}"
+  //Name of the server with index of count +1 to start from 1
+  name             = "${var.vmname}${count.index+1}${var.vmnamesuffix}"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  folder           = "${var.vmfolder}"
+
+  datastore_id = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus  = "${var.cpu_number}"
+  memory    = "${var.ram_size}"
+  guest_id  = "${data.vsphere_virtual_machine.template.guest_id}"
+  scsi_type = "${data.vsphere_virtual_machine.template.scsi_type}"
+  network_interface {
+    network_id   = "${data.vsphere_network.network.id}"
+    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+  }
+  network_interface {
+    network_id   = "${data.vsphere_network.network01.id}"
+    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+  }
+  network_interface {
+    network_id   = "${data.vsphere_network.network02.id}"
+    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+  }
+  disk {
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+  }
+  disk {
+    label            = "disk1"
+    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+  }
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+
+    customize {
+      linux_options {
+        host_name = "${var.vmname}${count.index+1}${var.vmnamesuffix}"
+        domain    = "${var.vmdomain}"
+      }
+      network_interface {
+        ipv4_address = "${element(var.net01-ip, count.index)}"
+        ipv4_netmask = "${var.net01-ipv4submask}"
+      }
+      network_interface {
+        ipv4_address = "${element(var.net02-ip, count.index)}"
+        ipv4_netmask = "${var.net02-ipv4submask}"
+      }
+      network_interface {
+        ipv4_address = "${element(var.net03-ip, count.index)}"
+        ipv4_netmask = "${var.net03-ipv4submask}"
+      }
+      dns_server_list = "${var.vmdns}"
+      ipv4_gateway    = "${var.vmgateway}"
+    }
+  }
+}
 // Creating Windows VM with no Data Disk.
 resource "vsphere_virtual_machine" "WindowsVM" {
   count            = "${ var.is_windows_image == "true" && var.data_disk == "false" && var.join_windomain == "false" ? var.instances : 0}"

--- a/variables.tf
+++ b/variables.tf
@@ -124,3 +124,9 @@ variable "productkey" {
   default = "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY"
 }
 
+variable "template_with_dual_disk" {
+  description = "Boolean Control Flag to deploy VMs based on Image with 2 disk configured"
+  default = "false"
+  
+}
+


### PR DESCRIPTION
Adding Support to Deploy Linux VMs with 2 Disks.

Possible use case scenarios to be used:

Terraform 11.
VM Image was created with a specific file system layout.
VM image was created with particular LVM configuration or RAID configurations.